### PR TITLE
problem with prop drilled image-url

### DIFF
--- a/frontend/src/components/ListView.js
+++ b/frontend/src/components/ListView.js
@@ -108,7 +108,7 @@ export default function ListView() {
                   type={placeData.type}
                   title={placeData.title}
                   street={placeData.street}
-                  primaryPicture={placeData.primaryPictureUrl}
+                  primaryPictureUrl={placeData.primaryPictureUrl}
                 />
               ))}
             </Grid>

--- a/frontend/src/components/ListView.js
+++ b/frontend/src/components/ListView.js
@@ -7,7 +7,7 @@ import michel from '../images/michel.jpg';
 import { Container, Grid } from '@material-ui/core';
 
 const placeData1 = {
-  id: 'michelsId',
+  id: 'Id1',
   primaryPictureUrl:
     'https://images.pexels.com/photos/2309270/pexels-photo-2309270.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260',
   type: 'landscape',
@@ -27,7 +27,7 @@ const placeData1 = {
   extraTwo: 'Ultraweitwinkel',
 };
 const placeData2 = {
-  id: 'karosId',
+  id: 'Id2',
   primaryPictureUrl: { michel },
   type: 'landscape',
   title: 'Die Karolinenstraße',
@@ -45,8 +45,46 @@ const placeData2 = {
   extraOne: '',
   extraTwo: '',
 };
+const placeData3 = {
+  id: 'Id3',
+  primaryPictureUrl: michel,
+  type: 'landscape',
+  title: 'Die Karolinenstraße',
+  street: 'Karolinenstraße 24',
+  address: 'Karolinenstraße 24, 20459 Hamburg',
+  placeDescription:
+    'Hamburgs bekannteste Kirche. Kann gerne betreten werden, aber bitte ohne Blitz fotografieren und die Hausregeln beachten. Der Eintritt zum Turm ist nicht gratis, aber dafür auch nicht umsonst, denn die Perspektive auf Hamburg ist einmalig und besonders zum Sonnenuntergang bietet sich ein einmaliges Panorama.',
+  pictureDescription:
+    'Bei diesem Bild heißt es Ausschau halten und in die Knie gehen. Der Durchgang vom Thielickestieg bietet einen natürlich Rahmen für den Michel. Geschossen wurden 9 Einzelaufnahmen, die danach zu einem Panorama zusammengesetzt worden sind. Zum einen vergrößert das den Blickwinkel, zum anderen natürlich die Pixelzahl und damit die maximal mögliche Druckgröße.',
+  aperture: 'f0',
+  focalLength: '20',
+  shutterSpeed: '160',
+  iso: '200',
+  youTubeUrl: 'https://youtu.be/xZuCQPrUFlc',
+  extraOne: '',
+  extraTwo: '',
+};
+const placeData4 = {
+  id: 'Id4',
+  primaryPictureUrl: michel,
+  type: 'landscape',
+  title: 'Die Karolinenstraße',
+  street: 'Karolinenstraße 24',
+  address: 'Karolinenstraße 24, 20459 Hamburg',
+  placeDescription:
+    'Hamburgs bekannteste Kirche. Kann gerne betreten werden, aber bitte ohne Blitz fotografieren und die Hausregeln beachten. Der Eintritt zum Turm ist nicht gratis, aber dafür auch nicht umsonst, denn die Perspektive auf Hamburg ist einmalig und besonders zum Sonnenuntergang bietet sich ein einmaliges Panorama.',
+  pictureDescription:
+    'Bei diesem Bild heißt es Ausschau halten und in die Knie gehen. Der Durchgang vom Thielickestieg bietet einen natürlich Rahmen für den Michel. Geschossen wurden 9 Einzelaufnahmen, die danach zu einem Panorama zusammengesetzt worden sind. Zum einen vergrößert das den Blickwinkel, zum anderen natürlich die Pixelzahl und damit die maximal mögliche Druckgröße.',
+  aperture: 'f0',
+  focalLength: '20',
+  shutterSpeed: '160',
+  iso: '200',
+  youTubeUrl: 'https://youtu.be/xZuCQPrUFlc',
+  extraOne: '',
+  extraTwo: '',
+};
 
-const placeDb = [placeData1, placeData2];
+const placeDb = [placeData1, placeData2, placeData3, placeData4];
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/frontend/src/components/ListView.js
+++ b/frontend/src/components/ListView.js
@@ -4,12 +4,12 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListCards from './cards/ListCards';
 import michel from '../images/michel.jpg';
-import karoviertel from '../images/karoviertel.jpg';
 import { Container, Grid } from '@material-ui/core';
 
 const placeData1 = {
   id: 'michelsId',
-  primaryPictureUrl: { karoviertel },
+  primaryPictureUrl:
+    'https://images.pexels.com/photos/2309270/pexels-photo-2309270.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260',
   type: 'landscape',
   title: 'Der Michel',
   street: 'Englische Planke 1',

--- a/frontend/src/components/ListView.js
+++ b/frontend/src/components/ListView.js
@@ -4,12 +4,13 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListCards from './cards/ListCards';
 import michel from '../images/michel.jpg';
+import karoviertel from '../images/karoviertel.jpg';
+import bruederstrasse from '../images/Bruederstraße.jpg';
 import { Container, Grid } from '@material-ui/core';
 
 const placeData1 = {
   id: 'Id1',
-  primaryPictureUrl:
-    'https://images.pexels.com/photos/2309270/pexels-photo-2309270.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260',
+  primaryPictureUrl: michel,
   type: 'landscape',
   title: 'Der Michel',
   street: 'Englische Planke 1',
@@ -28,7 +29,7 @@ const placeData1 = {
 };
 const placeData2 = {
   id: 'Id2',
-  primaryPictureUrl: { michel },
+  primaryPictureUrl: karoviertel,
   type: 'landscape',
   title: 'Die Karolinenstraße',
   street: 'Karolinenstraße 24',
@@ -46,12 +47,12 @@ const placeData2 = {
   extraTwo: '',
 };
 const placeData3 = {
-  id: 'Id3',
-  primaryPictureUrl: michel,
+  id: 'Id4',
+  primaryPictureUrl: bruederstrasse,
   type: 'landscape',
-  title: 'Die Karolinenstraße',
-  street: 'Karolinenstraße 24',
-  address: 'Karolinenstraße 24, 20459 Hamburg',
+  title: 'Die Brüderstrasse',
+  street: 'Brüderstrasse',
+  address: 'Brüderstrasse, 20259 Hamburg',
   placeDescription:
     'Hamburgs bekannteste Kirche. Kann gerne betreten werden, aber bitte ohne Blitz fotografieren und die Hausregeln beachten. Der Eintritt zum Turm ist nicht gratis, aber dafür auch nicht umsonst, denn die Perspektive auf Hamburg ist einmalig und besonders zum Sonnenuntergang bietet sich ein einmaliges Panorama.',
   pictureDescription:
@@ -65,7 +66,7 @@ const placeData3 = {
   extraTwo: '',
 };
 const placeData4 = {
-  id: 'Id4',
+  id: 'Id3',
   primaryPictureUrl: michel,
   type: 'landscape',
   title: 'Die Karolinenstraße',

--- a/frontend/src/components/cards/ListCards.js
+++ b/frontend/src/components/cards/ListCards.js
@@ -10,12 +10,12 @@ import { Container } from '@material-ui/core';
 
 const useStyles = makeStyles({
   media: {
-    paddingTop: '56.25%',
+    height: '25vh',
   },
 });
 
 export default function ListCards({ type, title, street, primaryPictureUrl }) {
-  const classes = useStyles({ ratio: 1.778 });
+  const classes = useStyles();
 
   return (
     <Container disableGutters={true}>
@@ -33,8 +33,8 @@ export default function ListCards({ type, title, street, primaryPictureUrl }) {
           <CardMedia
             className={classes.media}
             component={'img'}
-            src={
-              'https://cdn.taschen.com/media/images/1640/disney_mickey_mouse_xl_d_3d_01148_1811081034_id_1222966.png'
+            image={
+              'https://images.pexels.com/photos/2309270/pexels-photo-2309270.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
             }
             title={title}
           />

--- a/frontend/src/components/cards/ListCards.js
+++ b/frontend/src/components/cards/ListCards.js
@@ -33,9 +33,7 @@ export default function ListCards({ type, title, street, primaryPictureUrl }) {
           <CardMedia
             className={classes.media}
             component={'img'}
-            image={
-              'https://images.pexels.com/photos/2309270/pexels-photo-2309270.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
-            }
+            image={primaryPictureUrl}
             title={title}
           />
         </CardActionArea>


### PR DESCRIPTION
as long as i use a static url from OUTSIDE, my picture shows up.
as soon as i set a relative path to a local image or try using an import(`import michel from '../images/michel.jpg';`) and drilling it through to the CardMedia it does not render the image anymore.